### PR TITLE
Recursive definition using @@ (def@ @@ () body) is not working

### DIFF
--- a/@.el
+++ b/@.el
@@ -126,7 +126,11 @@ If :default, don't produce an error but return the provided value."
   (defun @--replace (symbol head)
     "Replace @: and @^: symbols with their lookup/funcall expansions."
     (let ((name (symbol-name symbol)))
-      (cond ((string-prefix-p "@:" name)
+      (cond ((string-match "^@@@@+$" name)
+             (let ((sym (intern (concat name "@@"))))
+               (if head
+                   (list sym) sym)))
+            ((string-prefix-p "@:" name)
              (let ((property (intern (substring name 1))))
                (if head
                    `(@! @@ ,property)
@@ -150,11 +154,11 @@ If :default, don't produce an error but return the provided value."
   `(progn
      (setf (@ ,object ,method)
            (cl-function
-            (lambda ,(cons '@@ params)
+            (lambda ,(cons '@@@@ params)
               ,@(if (stringp (car body)) (list (car body)) ())
               (let ((@@@ ,object))
                 (ignore @@@)
-                (with-@@ @@
+                (with-@@ @@@@
                  (ignore @@)
                  ,@(if (stringp (car body)) (cdr body) body))))))
      ,method))


### PR DESCRIPTION
Recursive def@ with @@ not work properly, with super method cause
infinite recursion.

defining recursively def@ with @@ a easy way to arrange related method of a
objects with them.

(progn
  (setf @test-base
        (let ((drived-obj (@extend @ :name "test-base")))

          (with-@@ drived-obj

            (setf @:doc "test base")

            (def@ @@ :init ()
              (message "@test-base :init start")
              (@^:init)
              (message "@test-base :init finish"))

            (def@ @@ :dispatch ()
              (message "@test-base :dispatch start")
              (@:init)
              (message "@test-base :dispatch finish"))

            (@:dispatch))
          drived-obj))

  (setf @test-base1
        (let ((drived-obj (@extend @test-base :name "test base1")))
          (with-@@ drived-obj

            (setf @:doc "test base1")

            (def@ @@ :init ()
              (message "@test-base1 :init start")
              (@^:init)
              (message "@test-base1 :init finish"))

            (def@ @@ :dispatch ()
              (message "@test-base1 :dispatch start")
              (@:init)
              (message "@test-base1 :dispatch finish"))

            (@:dispatch)) drived-obj)))