### PR TITLE
keyword regex for def@ and @:name are not getting matching

### DIFF
--- a/@.el
+++ b/@.el
@@ -164,12 +164,14 @@ If :default, don't produce an error but return the provided value."
      ,method))
 
 (font-lock-add-keywords 'emacs-lisp-mode
-  '(("(\\<\\(def@\\)\\> +\\([^ ()]+\\)"
+  ;; "(\\<\\(def@\\)\\> +\\([^ ()]+\\)"
+  '(("(\\<\\(def@\\) +\\([^ ()]+\\)"
      (1 'font-lock-keyword-face)
      (2 'font-lock-function-name-face))))
 
 (font-lock-add-keywords 'emacs-lisp-mode
-  '(("\\<\\(@\\^?:[^ ()]+\\)\\>"
+  ;; "\\<\\(@\\^?:[^ ()]+\\)\\>"
+  '(("\\(@\\^?:[^ ()]+\\)\\>"
      (1 'font-lock-builtin-face))))
 
 ;; Core methods


### PR DESCRIPTION
with Emacs version 25.2.1

where adjacent < or > to @ are not able to work with '@' char

(string-match "(\\<\\(def@\\)\\> +\\([^ ()]+\\)" "(def@ x")
=> nil

(string-match "(\\<\\(def@\\) +\\([^ ()]+\\)" "(def@ x")
=> 0

(string-match "\\<\\(@\\^?:[^ ()]+\\)\\>" "@:aa")
=> nil

(string-match "\\(@\\^?:[^ ()]+\\)\\>" "@:aa")
=> 0

changed regular expression accordingly.